### PR TITLE
Update hint.awk

### DIFF
--- a/toolkit-source/awk-programs/hint.awk
+++ b/toolkit-source/awk-programs/hint.awk
@@ -83,7 +83,7 @@ BEGIN {
 	pitch_pitch = "[ABCDEFG]"
 	Tonh_pitch = "Es|As|[ABCDEFGHS]"
 	solfg_pitch = "do|re|mi|fa|sol|la|si"
-	octave_class = "[^+-][0-9]"
+	octave_class = "[A-Gb#xHSaielosdn][0-9]"
 	options = ""
 	break_reg = ""
 	skip_reg = ""
@@ -742,8 +742,8 @@ function process_solfg(token  ,j,arrayd,split_num,found,semits,pitch,octave)
 				#
 				# Determine if there are any flats or sharps
 				#
-				if (match(arrayd[j],/_b+/)) semits -= (RLENGTH - 1)
-				else if (match(arrayd[j],/_d+/)) semits += (RLENGTH - 1)
+				if (match(arrayd[j],/~b+/)) semits -= (RLENGTH - 1)
+				else if (match(arrayd[j],/~d+/)) semits += (RLENGTH - 1)
 				#
 				# Determine which octave the note is in
 				#


### PR DESCRIPTION
1 - Updated regex for octave_class.  Previously, rhythmic durations with two digits would match an incorrect octave class (i.e. "16C4" would match octave class '6' instead of '4'), and pitch/tonh tokens which start with '(' or '[' would result in the first number of the rhythmic value being matched as the octave class (i.e. "(8C4" would match octave class '8').

The updated Regular Expression instead looks for a preceding pitch name or accidental (in **pitch, **tonh, or **solfg format), which prevents the previously described mismatches from occurring.

2 - Updated processing of **solfg accidentals from being denoted with '_' to '~'.  The previous implementation seemed to ignore accidentals applied to **solfg pitches.

A **kern representation of Beethoven's Sonata No. 8 in C minor was translated into **pitch, **tonh, and **solfg representations, all of which were used for testing these changes to hint.awk.